### PR TITLE
feat: Add CCIP SVM to EVM token transfer page

### DIFF
--- a/frontend/components/ccip-transfer-form.tsx
+++ b/frontend/components/ccip-transfer-form.tsx
@@ -12,7 +12,7 @@ import { WalletMultiButton } from "@solana/wallet-adapter-react-ui";
 import { PublicKey, SystemProgram, Transaction } from "@solana/web3.js";
 // Updated import path to the new frontend config file
 import { ChainId, CHAIN_SELECTORS, FeeTokenType as ConfigFeeTokenType, getFrontendCCIPSVMConfig, frontendTokens } from "@/lib/ccipConfig";
-import { CCIPRouterClient, TokenAmount } from "@chainlink/solana-sdk";
+import * as ChainlinkSolanaSDK from "@chainlink/solana-sdk";
 import { ethers } from "ethers";
 
 // Use constants from the new config file
@@ -91,7 +91,7 @@ export default function CCIPTransferForm() {
       const tokenDecimals = selectedToken.decimals;
       const rawAmount = ethers.parseUnits(tokenAmount, tokenDecimals).toString();
 
-      const tokenAmounts: TokenAmount[] = [{
+      const tokenAmounts: ChainlinkSolanaSDK.TokenAmount[] = [{ // Adjusted type
         tokenMint: new PublicKey(selectedTokenAddress),
         amount: rawAmount,
       }];


### PR DESCRIPTION
- Create new page for CCIP transfers (Solana to EVM).
- Implement CCIP transfer form component with fields for source/destination chains, token, amount, and receiver address.
- Add Solana wallet integration using @solana/wallet-adapter.
- Update ConnectWalletButton to use WalletMultiButton from @solana/wallet-adapter-react-ui.
- Move CCIP configuration to frontend/lib/ccipConfig.ts and update imports.
- Adjust @chainlink/solana-sdk import to use namespace for CCIPRouterClient.
- Include basic client-side validation and placeholder for CCIP transaction logic.
- Add navigation link to the new page.
- Delete unused `hooks/use-wallet.ts` to fix build error.